### PR TITLE
changed max_precision for real

### DIFF
--- a/include/real/real.hpp
+++ b/include/real/real.hpp
@@ -442,6 +442,7 @@ namespace boost {
                     _kind(other._kind),
                     _explicit_number(other._explicit_number),
                     _algorithmic_number(other._algorithmic_number),
+                    _maximum_precision(other.max_precision()),
                     _operation(other._operation) { this->copy_operands(other); };
 
             /**
@@ -555,12 +556,21 @@ namespace boost {
              *
              * @return and integer with the maximum allowed precision.
              */
+            
             unsigned int max_precision() const {
-                if (this->_maximum_precision == 0) {
-                    return boost::real::real::maximum_precision;
-                }
 
-                return this->_maximum_precision;
+                switch (this->_kind) {
+
+                    case KIND::EXPLICIT:
+                        return _explicit_number.max_precision();
+
+
+                    case KIND::ALGORITHM:
+                        return _algorithmic_number.max_precision();
+
+                    case KIND::OPERATION:
+                        return this->_maximum_precision;
+                }
             }
 
             /**
@@ -573,6 +583,8 @@ namespace boost {
              */
             void set_maximum_precision(unsigned int maximum_precision) {
                 this->_maximum_precision = maximum_precision;
+                this->_algorithmic_number.set_maximum_precision(maximum_precision);
+                this->_explicit_number.set_maximum_precision(maximum_precision);
             }
 
             /**
@@ -644,6 +656,7 @@ namespace boost {
                 this->_rhs_ptr = new real(other);
                 this->_kind = KIND::OPERATION;
                 this->_operation = OPERATION::ADDITION;
+                this->set_maximum_precision(std::max(this->max_precision(), other.max_precision()));
                 return *this;
             }
 
@@ -674,6 +687,7 @@ namespace boost {
                 this->_rhs_ptr = new real(other);
                 this->_kind = KIND::OPERATION;
                 this->_operation = OPERATION::SUBTRACT;
+                this->set_maximum_precision(std::max(this->max_precision(), other.max_precision()));
                 return *this;
             }
 
@@ -704,6 +718,7 @@ namespace boost {
                 this->_rhs_ptr = new real(other);
                 this->_kind = KIND::OPERATION;
                 this->_operation = OPERATION::MULTIPLICATION;
+                this->set_maximum_precision(std::max(this->max_precision(), other.max_precision()));
                 return *this;
             }
 

--- a/include/real/real_algorithm.hpp
+++ b/include/real/real_algorithm.hpp
@@ -204,7 +204,9 @@ namespace boost {
              * @param exponent - an integer representing the number exponent.
              */
             explicit real_algorithm(int (*get_nth_digit)(unsigned int), int exponent)
-                    : _get_nth_digit(get_nth_digit), _exponent(exponent), _positive(true) {}
+                    : _get_nth_digit(get_nth_digit), _exponent(exponent), _positive(true) {
+                        set_maximum_precision(15);
+                    }
 
             /**
              * @brief *Lambda function constructor with exponent and sign:* Creates a boost::real::real_algorithm instance
@@ -224,7 +226,9 @@ namespace boost {
                                     bool positive)
                     : _get_nth_digit(get_nth_digit),
                       _exponent(exponent),
-                      _positive(positive) {}
+                      _positive(positive) {
+                          set_maximum_precision(15);
+                      }
 
             /**
              * @brief Returns the maximum allowed precision, if that precision is reached and an
@@ -233,7 +237,7 @@ namespace boost {
              * @return an integer with the maximum allowed precision.
              */
             unsigned int max_precision() const {
-                return boost::real::real_algorithm::maximum_precision;
+                return this->_maximum_precision;
             }
 
             /**
@@ -281,7 +285,7 @@ namespace boost {
              */
             const_precision_iterator cend() const {
                 const_precision_iterator it(this);
-                it.iterate_n_times(boost::real::real_algorithm::maximum_precision - 1);
+                it.iterate_n_times(this->max_precision() - 1);
                 return it;
             }
 

--- a/test/real_algorithm_iterator_unit_test.cpp
+++ b/test/real_algorithm_iterator_unit_test.cpp
@@ -149,7 +149,7 @@ TEST_CASE("Iterator cend") {
 
     SECTION("Iterate until the maximum set precision returns the end of the iterator") {
 
-        for(int i = 0; i < 9; i++) {
+        for(int i = 0; i < 14; i++) {
             CHECK_FALSE( approximation_it == end_it );
             ++approximation_it;
         }

--- a/test/real_eq_operator_test.cpp
+++ b/test/real_eq_operator_test.cpp
@@ -162,17 +162,17 @@ TEST_CASE("Operator ==") {
 
         SECTION("With precision exception") {
             SECTION("Explicit == Algorithm") {
-                boost::real::real a("1.11");
+                boost::real::real a("1.111");
                 boost::real::real b(one_one_one, 1);
 
-                CHECK_THROWS_AS(a == b, boost::real::precision_exception);
+                CHECK_FALSE(a == b);
             }
 
             SECTION("Explicit == Explicit") {
                 boost::real::real a("1.555555555555555555");
                 boost::real::real b("1.555555555555555555");
 
-                CHECK_THROWS_AS(a == b, boost::real::precision_exception);
+                CHECK(a == b);
             }
 
             SECTION("Explicit == Addition") {
@@ -181,7 +181,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("11111111111110000000000");
                 boost::real::real d = b + c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK(a == d);
             }
 
             SECTION("Explicit == Subtraction") {
@@ -190,7 +190,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("1");
                 boost::real::real d = b - c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK(a == d);
             }
 
             SECTION("Explicit == multiplication") {
@@ -199,7 +199,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("2");
                 boost::real::real d = b * c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK(a == d);
             }
 
             SECTION("Addition == Explicit") {
@@ -208,7 +208,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Addition == Addition") {
@@ -217,7 +217,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + b;
                 boost::real::real d = a + b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Addition == Subtraction") {
@@ -228,7 +228,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK(c == f);
             }
 
             SECTION("Addition == multiplication") {
@@ -238,7 +238,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("2");
                 boost::real::real e = a * d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK(c == e);
             }
 
             SECTION("Subtraction == Explicit") {
@@ -247,7 +247,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a - b;
                 boost::real::real d("1.1111111111111");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Subtraction == Addition") {
@@ -257,7 +257,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("-0.0000000000001");
                 boost::real::real e = a + d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK(c == e);
             }
 
             SECTION("Subtraction == Subtraction") {
@@ -266,7 +266,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a - b;
                 boost::real::real d = a - b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Subtraction == multiplication") {
@@ -277,7 +277,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("1");
                 boost::real::real f = d * e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK(c == f);
             }
 
             SECTION("multiplication == Explicit") {
@@ -286,7 +286,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("multiplication == Addition") {
@@ -295,7 +295,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d = a + a;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("multiplication == Subtraction") {
@@ -306,7 +306,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK(c == f);
             }
 
             SECTION("multiplication == multiplication") {
@@ -315,7 +315,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d = a * b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
         }
     }
@@ -482,7 +482,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real a("1.555555555555555550");
                 boost::real::real b("1.555555555555555555");
 
-                CHECK_THROWS_AS(a == b, boost::real::precision_exception);
+                CHECK_FALSE(a == b);
             }
 
             SECTION("Explicit == Addition") {
@@ -491,7 +491,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("11111111111110000000000");
                 boost::real::real d = b + c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Explicit == Subtraction") {
@@ -500,7 +500,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("1");
                 boost::real::real d = b - c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Explicit == multiplication") {
@@ -509,7 +509,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("2");
                 boost::real::real d = b * c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Addition == Explicit") {
@@ -518,7 +518,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("Addition == Addition") {
@@ -527,7 +527,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + b;
                 boost::real::real d = a + b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Addition == Subtraction") {
@@ -538,7 +538,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("Addition == multiplication") {
@@ -548,7 +548,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("2");
                 boost::real::real e = a * d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
             }
 
             SECTION("Subtraction == Explicit") {
@@ -557,7 +557,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a - b;
                 boost::real::real d("1.1111111111111");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("Subtraction == Addition") {
@@ -567,7 +567,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("-0.0000000000001");
                 boost::real::real e = a + d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK(c == e);
             }
 
             SECTION("Subtraction == Subtraction") {
@@ -576,7 +576,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a - b;
                 boost::real::real d = a - b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("Subtraction == multiplication") {
@@ -587,7 +587,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("1");
                 boost::real::real f = d * e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("multiplication == Explicit") {
@@ -596,7 +596,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("multiplication == Addition") {
@@ -605,7 +605,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d = a + a;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
 
             SECTION("multiplication == Subtraction") {
@@ -616,7 +616,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("multiplication == multiplication") {
@@ -625,7 +625,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d = a * b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK(c == d);
             }
         }
 
@@ -791,7 +791,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real a("1.555555555555555555");
                 boost::real::real b("1.5555555555555555");
 
-                CHECK_THROWS_AS(a == b, boost::real::precision_exception);
+                CHECK_FALSE(a == b);
             }
 
             SECTION("Explicit == Addition") {
@@ -800,7 +800,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("11111111111110000000000");
                 boost::real::real d = b + c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Explicit == Subtraction") {
@@ -809,7 +809,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("1");
                 boost::real::real d = b - c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Explicit == multiplication") {
@@ -818,7 +818,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c("2");
                 boost::real::real d = b * c;
 
-                CHECK_THROWS_AS(a == d, boost::real::precision_exception);
+                CHECK_FALSE(a == d);
             }
 
             SECTION("Addition == Explicit") {
@@ -827,7 +827,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("Addition == Addition") {
@@ -836,7 +836,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a + a;
                 boost::real::real d = b + b;
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("Addition == Subtraction") {
@@ -847,7 +847,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("Addition == multiplication") {
@@ -857,7 +857,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("2");
                 boost::real::real e = a * d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
             }
 
             SECTION("Subtraction == Explicit") {
@@ -866,7 +866,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a - b;
                 boost::real::real d("1.1111111111111");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("Subtraction == Addition") {
@@ -876,7 +876,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("-0.0000000000003");
                 boost::real::real e = a + d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
             }
 
             SECTION("Subtraction == Subtraction") {
@@ -886,7 +886,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("0.0000000000003");
                 boost::real::real e = a - d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
             }
 
             SECTION("Subtraction == multiplication") {
@@ -897,7 +897,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("1");
                 boost::real::real f = d * e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("multiplication == Explicit") {
@@ -906,7 +906,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d("2.2222222222222");
 
-                CHECK_THROWS_AS(c == d, boost::real::precision_exception);
+                CHECK_FALSE(c == d);
             }
 
             SECTION("multiplication == Addition") {
@@ -916,7 +916,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real d("1.1111111111100");
                 boost::real::real e = a + d;
 
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
             }
 
             SECTION("multiplication == Subtraction") {
@@ -927,7 +927,7 @@ TEST_CASE("Operator ==") {
                 boost::real::real e("0.0000000000001");
                 boost::real::real f = d - e;
 
-                CHECK_THROWS_AS(c == f, boost::real::precision_exception);
+                CHECK_FALSE(c == f);
             }
 
             SECTION("multiplication == multiplication") {
@@ -936,7 +936,55 @@ TEST_CASE("Operator ==") {
                 boost::real::real c = a * b;
                 boost::real::real d("1.1111111111111");
                 boost::real::real e = d * b;
-                CHECK_THROWS_AS(c == e, boost::real::precision_exception);
+                CHECK_FALSE(c == e);
+            }
+        }
+    }
+
+    SECTION("My Tests") {
+
+        SECTION("without precision exception") {
+            SECTION("Explicit == Explicit") {
+                boost::real::real a("1.590342342342433345364656757586767");
+                boost::real::real b("1.590342342342433345364656757586767");
+
+                CHECK(a == b);
+            }
+
+            SECTION("Explicit == Explicit") {
+                boost::real::real a("1.590342342342433345364656757586767");
+                boost::real::real b("1.590342342342433345364656757586767");
+                a.set_maximum_precision(5);
+                b.set_maximum_precision(5);
+
+                CHECK_THROWS_AS(a == b, boost::real::precision_exception);
+            }
+
+            SECTION("Explicit != Explicit") {
+                boost::real::real a("1.590342342342433345364656757596767");
+                boost::real::real b("1.590342342342433345364656757586767");
+
+                CHECK_FALSE(a == b);
+            }
+
+            SECTION("Explicit != Explicit") {
+                boost::real::real a("1.59034234234243334");
+                boost::real::real b("1.590342342342433345364656757586767");
+
+                CHECK_FALSE(a == b);
+            }
+            SECTION("Explicit == Explicit") {
+                boost::real::real a("1.59034234234243334");
+                boost::real::real b("1.59034234234243334000000000");
+
+                CHECK(a == b);
+            }
+            SECTION("For debug") {
+                boost::real::real a("2.3");
+                boost::real::real b("1.2");
+                boost::real::real c = a*b;
+                boost::real::real d("2.76");
+                CHECK(c == d);
             }
         }
     }


### PR DESCRIPTION
Currently only the greater than and less than operator tests don't pass. They will need similar changes as in the == operator test. That is: remove precision exception checks where a comparison is possible and just check the functioning of < operator. I also added a few tests under My Tests section in the real eq operator test. I didn't make the changes in the <, > operator tests as I wanted to confirm whether this is correct. If yes, I'll update once again. All other tests except these two are still passing. These two are the real_lower_than_operator_test and real_greater_than_operator_test.